### PR TITLE
Add pre-Remiem Belgemine locations

### DIFF
--- a/worlds/ffx/data/regions.json
+++ b/worlds/ffx/data/regions.json
@@ -187,7 +187,7 @@
   {
     "name": "Mi'ihen Highroad 1st visit: Pre-Chocobo Eater",
     "id": 40,
-    "treasures": [311, 309, 310, 38, 44, 313, 312, 317, 318, 45, 316, 314, 315, 46, 423, 97],
+    "treasures": [311, 309, 310, 38, 44, 313, 312, 317, 318, 45, 316, 314, 315, 46, 423, 97, 186],
     "party_members": [],
     "bosses": [],
     "overdrives": [],
@@ -286,13 +286,13 @@
   {
     "name": "Moonflow 1st visit: Pre-Extractor",
     "id": 70,
-    "treasures": [376, 197, 377, 378, 198, 199],
+    "treasures": [376, 197, 377, 378, 198, 199, 372],
     "party_members": [],
     "bosses": [],
     "overdrives": [],
     "other": [],
     "recruits": [],
-    "leads_to": [71, 1013, 1014],
+    "leads_to": [71, 1013, 1014, 1100],
     "rules": ["Moonflow"]
   },
   {
@@ -629,13 +629,13 @@
   {
     "name": "Calm Lands 1st visit: Pre-Defender X",
     "id": 140,
-    "treasures": [116, 115, 117],
+    "treasures": [116, 115, 117, 187],
     "party_members": [],
     "bosses": [],
     "overdrives": [],
     "other": [23],
     "recruits": [11, 17],
-    "leads_to": [141, 142, 1015],
+    "leads_to": [141, 142, 1015, 1101],
     "rules": ["Calm Lands"]
   },
   {
@@ -1096,6 +1096,30 @@
     "name": "Captures: Inside Sin & Omega Ruins Post-Omega Weapon",
     "id": 1023,
     "treasures": [],
+    "party_members": [],
+    "bosses": [],
+    "overdrives": [],
+    "other": [],
+    "recruits": [],
+    "leads_to": [],
+    "rules": []
+  },
+  {
+    "name": "Summoner's Soul",
+    "id": 1100,
+    "treasures": [374],
+    "party_members": [],
+    "bosses": [],
+    "overdrives": [],
+    "other": [],
+    "recruits": [],
+    "leads_to": [],
+    "rules": []
+  },
+  {
+    "name": "Aeon's Soul",
+    "id": 1101,
+    "treasures": [371],
     "party_members": [],
     "bosses": [],
     "overdrives": [],

--- a/worlds/ffx/locations.py
+++ b/worlds/ffx/locations.py
@@ -522,7 +522,7 @@ FFXTreasureLocations: List[FFXLocationData] = [ FFXLocationData(location[1]+Trea
     ("THPL: North - West Side, Near North Exit (Chest)",                                            184, False),  # Item: 1x Remedy [200Fh]
     ("THPL: North - East of Final Lightning Rod (Chest)",                                           185, False),  # Gil: 2000 [14h]
     ("MIHN: South End - Fight Belgemine (Win) (Event)",                                             186, False),  # Gear: buki_get #74 [4Ah] { Yuna [01h], Armor {HP +10% [8073h], Silence Ward [8045h]} }
-    ("REMI: Beat Belgemine (NPC)",                                                                  187, False),  # Item: 30x Power Sphere [2046h]
+    ("CALM: Central - Fight Belgemine (Win) (Event)",                                               187, False),  # Item: 30x Power Sphere [2046h]
     ("THPL: Cactuar Statue Minigame (Event)",                                                       188, False),  # Gear: buki_get #56 [38h] { Kimahri [03h], Weapon Formula=Celestial HP-based [11h] {No AP [8014h], Empty, Empty, Empty} }
     ("THPL: Lightning Dodger - 5 Consecutive Dodges (Event)",                                       189, False),  # Item: 2x X-Potion [2002h]
     ("THPL: Lightning Dodger - 10 Consecutive Dodges (Event)",                                      190, False),  # Item: 2x Mega-Potion [2003h]
@@ -701,14 +701,14 @@ FFXTreasureLocations: List[FFXLocationData] = [ FFXLocationData(location[1]+Trea
     ("HOME: Outside Summoner's Sanctum - Left (Chest)",                                             363, False),  # Item: 1x Lv. 4 Key Sphere [2054h]
     ("HOME: Environment Controls (Chest)",                                                          364, False),  # Gil: 10000 [64h]
     ("SSWI: Deck - Top Floor, Counting Gulls (NPC)",                                                365, False),  # Gear: buki_get #70 [46h] { Wakka [04h], Weapon {Magic +20% [8069h], Magic +10% [8068h], Magic +5% [8067h], Magic +3% [8066h]} }
-    ("MIHN: South End - Fight Belgemine (Lose) (Event)",                                            366, False),  # Gear: buki_get #71 [47h] { Yuna [01h], Armor {HP +10% [8073h], Empty} }
+    #("MIHN: South End - Fight Belgemine (Lose) (Event)",                                            366, False),  # Gear: buki_get #71 [47h] { Yuna [01h], Armor {HP +10% [8073h], Empty} }
     ("HOME: Keyakku, on Ground (NPC)",                                                              367, False),  # Item: 2x Hi-Potion [2001h]
     #("MUSH: Valley - Code VICTORIOUS",                                                             368, False),  # Gear: buki_get #72 [48h] { Rikku [06h], Armor {Lightningproof [8028h], Fireproof [8020h], Iceproof [8024h], Empty} } UNCOMMENT WHEN CODES ARE INCORPORATED
     #("BSIL: BSIL Ruins - Code MURASAME",                                                           369, False),  # Gear: buki_get #73 [49h] { Auron [02h], Weapon {Piercing [800Bh], One MP Cost [800Dh], Empty, Empty} } UNCOMMENT WHEN CODES ARE INCORPORATED
     ("CALM: Speed Sphere x30 (Lose Aeon Fight)",                                                    370, False),  # Item: 30x Speed Sphere [2048h]
     ("Defeat Belgemine Twice",                                                                      371, False),  # Key Item: Aeon's Soul [A01Fh]
-    ("MOON: South Bank Road - Fight Belgemine (Win) (Event) (1)",                                   372, False),  # Item: 2x Dragon Scale [2021h]
-    ("MOON: South Bank Road - Fight Belgemine (Lose) (Event) (1)",                                  373, False),  # Item: 6x Smoke Bomb [2028h]
+    ("MOON: South Bank Road - Fight Belgemine (Win) (Event)",                                       372, False),  # Item: 2x Dragon Scale [2021h]
+    #("MOON: South Bank Road - Fight Belgemine (Lose) (Event)",                                     373, False),  # Item: 6x Smoke Bomb [2028h]
     ("Defeat Belgemine Once",                                                                       374, False),  # Key Item: Summoner's Soul [A01Eh]
     ("AIRS: Cabin - Before Evrae, Yellow Al Bhed on Left (NPC)",                                    375, False),  # Item: 4x Al Bhed Potion [2014h]
     ("MOON: South Bank Road - Right of Shelinda (Chest)",                                           376, False),  # Item: 3x Lv. 1 Key Sphere [2051h]

--- a/worlds/ffx/regions.py
+++ b/worlds/ffx/regions.py
@@ -6,7 +6,7 @@ from typing import NamedTuple, List
 
 from .locations import FFXLocation, FFXTreasureLocations, FFXPartyMemberLocations, FFXBossLocations, \
     FFXOverdriveLocations, FFXOtherLocations, FFXRecruitLocations, FFXSphereGridLocations, FFXCaptureLocations, FFXLocationData, TreasureOffset, BossOffset, PartyMemberOffset, RecruitOffset, CaptureOffset, OtherOffset
-from .rules import ruleDict
+from .rules import ruleDict, create_min_summon_rule
 from .items import party_member_items, key_items, FFXItem
 from worlds.generic.Rules import add_rule
 from ..AutoWorld import World
@@ -316,6 +316,12 @@ def create_regions(world: FFXWorld, player) -> None:
                 new_rule = None
             menu_entrance: Entrance = menu_region.connect(other_region, rule=new_rule)
             top_level_regions.append((other_region, menu_entrance))
+
+    # Connect Remiem Temple to Summoner's Soul and Aeon's Soul
+    # Defined here instead of regions.json because there is no rule from Moonflow/Calm Lands
+    remiem_region = region_dict[141]
+    remiem_region.connect(region_dict[1100], rule=create_min_summon_rule(world, 2))
+    remiem_region.connect(region_dict[1101], rule=create_min_summon_rule(world, 2))
 
     #for this_region, _ in top_level_regions:
     #    for other_region, menu_entrance in top_level_regions:

--- a/worlds/ffx/rules.py
+++ b/worlds/ffx/rules.py
@@ -263,6 +263,13 @@ def set_rules(world: FFXWorld) -> None:
     # Send Belgemine? (Moon sigil)
     add_rule(world.get_location(world.location_id_to_name[275 | TreasureOffset]), lambda state: state.has(f"Party Member: Yuna", world.player) and state.has_all([f"Party Member: {name}" for name in ["Yojimbo", "Anima", "Magus Sisters"]], world.player))
 
+    ## Belgemine
+    # Mi'ihen fight
+    add_rule(world.get_location(world.location_id_to_name[186 | TreasureOffset]), create_min_summon_rule(world, 2))
+    # Moonflow fight
+    add_rule(world.get_location(world.location_id_to_name[372 | TreasureOffset]), create_min_summon_rule(world, 2))
+    # Calm Lands fight
+    add_rule(world.get_location(world.location_id_to_name[187 | TreasureOffset]), create_min_summon_rule(world, 2))
 
     ## Dark Aeons
     dark_aeons = [


### PR DESCRIPTION
This resolves #33 by adding the win rewards for the pre-Remiem Belgemine fights as locations as well as the Aeon's/Summoner's Soul rewards which can also be obtained in Remiem.

The locations for Aeon's/Summoner's Soul should probably be renamed before next release.