### PR TITLE
Blitz recruits in regions

### DIFF
--- a/worlds/ffx/data/regions.json
+++ b/worlds/ffx/data/regions.json
@@ -44,7 +44,7 @@
     "bosses": [],
     "overdrives": [21],
     "other": [0, 2],
-    "recruits": [19],
+    "recruits": [52],
     "leads_to": [11],
     "rules": ["Besaid"]
   },
@@ -93,11 +93,10 @@
     "bosses": [5],
     "overdrives": [],
     "other": [4],
-    "recruits": [18],
+    "recruits": [13, 14, 15, 16],
     "leads_to": [21],
     "rules": ["Kilika"]
   },
-
   {
     "name": "Kilika 1st visit: Post-Geneaux",
     "id": 21,
@@ -106,7 +105,7 @@
     "bosses": [6],
     "overdrives": [],
     "other": [],
-    "recruits": [8],
+    "recruits": [17, 18, 46],
     "leads_to": [22],
     "rules": ["Sinspawn Geneaux"]
   },
@@ -118,7 +117,7 @@
     "bosses": [],
     "overdrives": [],
     "other": [36],
-    "recruits": [5],
+    "recruits": [],
     "leads_to": [23, 1002],
     "rules": []
   },
@@ -142,7 +141,7 @@
     "bosses": [],
     "overdrives": [],
     "other": [],
-    "recruits": [],
+    "recruits": [56],
     "leads_to": [],
     "rules": []
   },
@@ -155,7 +154,7 @@
     "bosses": [],
     "overdrives": [],
     "other": [6, 7],
-    "recruits": [1, 4, 12, 15, 21, 23, 24],
+    "recruits": [2, 3, 4, 5, 6, 41, 42, 43, 47, 50, 53, 54],
     "leads_to": [31],
     "rules": ["Luca"]
   },
@@ -167,7 +166,7 @@
     "bosses": [7],
     "overdrives": [],
     "other": [],
-    "recruits": [],
+    "recruits": [7, 8, 9, 10, 11, 12, 25, 26, 27, 28, 29, 30, 40],
     "leads_to": [32],
     "rules": ["Oblitzerator"]
   },
@@ -179,7 +178,7 @@
     "bosses": [],
     "overdrives": [],
     "other": [31],
-    "recruits": [16],
+    "recruits": [],
     "leads_to": [],
     "rules": []
   },
@@ -192,7 +191,7 @@
     "bosses": [],
     "overdrives": [],
     "other": [8],
-    "recruits": [14],
+    "recruits": [44],
     "leads_to": [41, 1010],
     "rules": ["Mi'ihen Highroad"]
   },
@@ -266,7 +265,7 @@
     "bosses": [],
     "overdrives": [],
     "other": [11],
-    "recruits": [6],
+    "recruits": [39],
     "leads_to": [61, 1012, 1013, 1014],
     "rules": ["Djose"]
   },
@@ -303,7 +302,7 @@
     "bosses": [12],
     "overdrives": [],
     "other": [12],
-    "recruits": [10],
+    "recruits": [59],
     "leads_to": [72],
     "rules": ["Extractor"]
   },
@@ -328,7 +327,7 @@
     "bosses": [],
     "overdrives": [],
     "other": [13, 37],
-    "recruits": [22],
+    "recruits": [31, 32, 33, 34, 35, 36, 55],
     "leads_to": [81],
     "rules": ["Guadosalam"]
   },
@@ -353,7 +352,7 @@
     "bosses": [],
     "overdrives": [],
     "other": [],
-    "recruits": [9],
+    "recruits": [58],
     "leads_to": [91, 1003],
     "rules": ["Thunder Plains"]
   },
@@ -414,7 +413,7 @@
     "bosses": [15],
     "overdrives": [],
     "other": [],
-    "recruits": [7],
+    "recruits": [45],
     "leads_to": [104],
     "rules": ["Crawler"]
   },
@@ -512,7 +511,7 @@
     "bosses": [],
     "overdrives": [],
     "other": [],
-    "recruits": [2, 13, 20],
+    "recruits": [1, 19, 20, 21, 22, 23, 24, 37, 57],
     "leads_to": [121],
     "rules": ["Airship"]
   },
@@ -634,7 +633,7 @@
     "bosses": [],
     "overdrives": [],
     "other": [23],
-    "recruits": [11, 17],
+    "recruits": [48, 51],
     "leads_to": [141, 142, 1015, 1101],
     "rules": ["Calm Lands"]
   },
@@ -683,7 +682,7 @@
     "bosses": [],
     "overdrives": [],
     "other": [25],
-    "recruits": [3],
+    "recruits": [49],
     "leads_to": [151, 1016, 1015, 1022],
     "rules": ["Cavern of the Stolen Fayth"]
   },


### PR DESCRIPTION
Resolves #66

Adds the new blitz recruits to the `regions.json` to place them within their relevant logical regions