### PR TITLE
Fix Recruit Exclusions

### DIFF
--- a/worlds/ffx/regions.py
+++ b/worlds/ffx/regions.py
@@ -486,17 +486,15 @@ def create_regions(world: FFXWorld, player) -> None:
 
     if not world.options.recruit_sanity.value is world.options.recruit_sanity.option_all:
         recruit_location_ids = []
-        contracted_ids = [loc.location_id for loc in FFXRecruitLocations[2:37]]
-        free_agent_ids = [loc.location_id for loc in [FFXRecruitLocations[1], *FFXRecruitLocations[38:]]]
+        contracted_ids = [loc.location_id for loc in FFXRecruitLocations[1:36]]
+        free_agent_ids = [loc.location_id for loc in [FFXRecruitLocations[0], *FFXRecruitLocations[36:]]]
 
         including = world.options.recruit_sanity.value
-        none = world.options.recruit_sanity.option_off
-        free_agents = world.options.recruit_sanity.option_free_agents
 
-        if including is free_agents or none:
+        if including < world.options.recruit_sanity.option_all:
             recruit_location_ids.extend(contracted_ids)
         
-        if including is none:
+        if including == world.options.recruit_sanity.option_off:
             recruit_location_ids.extend(free_agent_ids)
 
         for id in recruit_location_ids:


### PR DESCRIPTION
Resolves #103 

Currently contracted agents are never being excluded, due to incorrect list slicing & options comparisons.
This PR corrects both points.