### PR TITLE
Split Omega Weapon & Dark Aeons options

### DIFF
--- a/worlds/ffx/options.py
+++ b/worlds/ffx/options.py
@@ -266,8 +266,8 @@ class EncounterWeighting(NamedRange):
 class SuperBosses(Choice):
     """
     Sets whether Super Boss locations are included or not. If off they will only have filler items.
-    - Omega Weapon: Enables the Omega Weapon boss fight in Omega Ruins
-    - Dark Aeons: Enables the Dark Aeon checks around Spira, as well as the above,
+    - Omega Weapon: Enables the Omega Weapon boss fight in Omega Ruins.
+    - Dark Aeons: Enables the Dark Aeon checks around Spira, as well as the above.
     Default is off.
     """
     display_name = "Super Bosses"

--- a/worlds/ffx/options.py
+++ b/worlds/ffx/options.py
@@ -263,16 +263,18 @@ class EncounterWeighting(NamedRange):
     }
 
 
-class SuperBosses(Toggle):
+class SuperBosses(Choice):
     """
     Sets whether Super Boss locations are included or not. If off they will only have filler items.
-    Super Bosses include Omega Weapon, the Dark Aeons & Penance.
+    - Omega Weapon: Enables the Omega Weapon boss fight in Omega Ruins
+    - Dark Aeons: Enables the Dark Aeon checks around Spira, as well as the above,
     Default is off.
     """
     display_name = "Super Bosses"
     default = 0
     option_off = 0
-    option_on = 1
+    option_omega_weapon = 1
+    option_dark_aeons = 2
 
 
 class JechtSpheres(Toggle):

--- a/worlds/ffx/regions.py
+++ b/worlds/ffx/regions.py
@@ -491,27 +491,34 @@ def create_regions(world: FFXWorld, player) -> None:
         world.skip_locations.add(location_name)
 
     # ----------------------------- Super Bosses ----------------------------- #
-    if not world.options.super_bosses.value:
-        super_boss_location_ids = [
-             2, # "Besaid: Dark Valefor"
-            19, # "Bikanel: Dark Ifrit"
-            13, # "Thunder Plains: Dark Ixion"
-            18, # "Lake Macalania: Dark Shiva"
-            38, # "Zanarkand: Dark Bahamut"
-            31, # "Cavern of the Stolen Fayth: Dark Yojimbo"
-            45, # "Mushroom Rock Road: Dark Mindy"
-            46, # "Mushroom Rock Road: Dark Sandy"
-            47, # "Mushroom Rock Road: Dark Cindy"
-            34, # "Gagazet (Outside): Dark Anima"
-          # 25, # "Airship: Penance"
-            44, # "Omega Ruins: Omega Weapon"
-        ]
-        super_boss_treasure_ids = [
-            332, # OMGR: Omega Boss Arena (Chest)
-        ]
-        super_boss_other_ids = [
-            27, # Jecht Sphere 2 - Requires Dark Valefor
-        ]
+    if not world.options.super_bosses.value == world.options.super_bosses.option_dark_aeons:
+        super_boss_location_ids = []
+        super_boss_treasure_ids = []
+        super_boss_other_ids    = []
+
+        up_to       = world.options.super_bosses
+        up_to_omega = world.options.super_bosses.option_omega_weapon
+        up_to_aeons = world.options.super_bosses.option_dark_aeons
+
+        if up_to < up_to_aeons:
+            super_boss_location_ids.extend([
+                 2, # "Besaid: Dark Valefor"
+                19, # "Bikanel: Dark Ifrit"
+                13, # "Thunder Plains: Dark Ixion"
+                18, # "Lake Macalania: Dark Shiva"
+                38, # "Zanarkand: Dark Bahamut"
+                31, # "Cavern of the Stolen Fayth: Dark Yojimbo"
+                45, # "Mushroom Rock Road: Dark Mindy"
+                46, # "Mushroom Rock Road: Dark Sandy"
+                47, # "Mushroom Rock Road: Dark Cindy"
+                34, # "Gagazet (Outside): Dark Anima"
+            ])
+            super_boss_other_ids.append(27) # Jecht Sphere 2 - Requires Dark Valefor
+        
+        if up_to < up_to_omega:
+            super_boss_location_ids.append(44) # "Omega Ruins: Omega Weapon"
+            super_boss_treasure_ids.append(332) # OMGR: Omega Boss Arena (Chest)
+
         for id in super_boss_location_ids:
             location_name = world.location_id_to_name[id | BossOffset]
             world.skip_locations.add(location_name)


### PR DESCRIPTION
Resolves #141 

Allows for Omega Weapon to be enabled, without adding in all the Dark Aeons as well, as there is a significant difficulty jump between the two