### PR TITLE
Slot Data & UT Passthrough for Goal and Skip Contest

### DIFF
--- a/worlds/ffx/__init__.py
+++ b/worlds/ffx/__init__.py
@@ -247,7 +247,8 @@ class FFXWorld(World):
             "super_bosses": self.options.super_bosses.value,
             "jecht_spheres": self.options.jecht_spheres.value,
             "always_capture": self.options.always_capture.value,
-            "logic_difficulty": self.options.logic_difficulty.value,            
+            "logic_difficulty": self.options.logic_difficulty.value,
+            "skip_contest_of_aeons": self.options.skip_contest_of_aeons,
         }
         return slot_data
 

--- a/worlds/ffx/ut.py
+++ b/worlds/ffx/ut.py
@@ -31,6 +31,7 @@ def setup_options_from_slot_data(world: FFXWorld) -> None:
             world.options.jecht_spheres.value               = world.passthrough["jecht_spheres"]
             world.options.always_capture.value              = world.passthrough["always_capture"]
             world.options.logic_difficulty.value            = world.passthrough["logic_difficulty"]
+            world.options.skip_contest_of_aeons.value       = world.passthrough["skip_contest_of_aeons"]
             
             
 

--- a/worlds/ffx/ut.py
+++ b/worlds/ffx/ut.py
@@ -11,6 +11,7 @@ def setup_options_from_slot_data(world: FFXWorld) -> None:
             world.using_ut = True
             world.passthrough = world.multiworld.re_gen_passthrough["Final Fantasy X"]
 
+            world.options.goal.value                        = world.passthrough["goal"]
             world.options.goal_requirement.value            = world.passthrough["goal_requirement"]
             world.options.required_party_members.value      = world.passthrough["required_party_members"]
             world.options.required_primers.value            = world.passthrough["required_primers"]


### PR DESCRIPTION
Always make BFA & Contest locations active, alongside Yu Yevon, regardless of goal.
Therefore;
- Goal = Yu Yevon
  - A couple of extra checks along the way to goal, no harm, minimal benefit
- Goal = Nemesis
  - Ensures that the final gauntlet has 3 checks associated with it (BFA, Contest & Yu Yevon), as opposed to just the 1.
  - Helps make the time investment into that gauntlet feel more worthwhile.

Also included the Skip Contest option into slot data, for Poptracker compatability.