### PR TITLE
Basic Seymour Logic

### DIFF
--- a/worlds/ffx/__init__.py
+++ b/worlds/ffx/__init__.py
@@ -3,7 +3,6 @@ Archipelago World definition for Final Fantasy X
 """
 
 from typing import ClassVar, Any, Optional
-from random import choice, Random, shuffle
 from settings import Group, FilePath
 
 from BaseClasses import Tutorial, Item, ItemClassification, LocationProgressType
@@ -159,7 +158,7 @@ class FFXWorld(World):
         
         if self.options.early_party_members.value > 0:
             partyMembers = party_member_items[1:8]
-            shuffle(partyMembers)
+            self.random.shuffle(partyMembers)
             for i in range(self.options.early_party_members.value):
                 self.multiworld.early_items[self.player][partyMembers.pop(0).itemName] = 1
         
@@ -168,10 +167,10 @@ class FFXWorld(World):
             required_items.append(overdrive.itemName)
         
         if self.options.tidus_early_overdrive_access.value is self.options.tidus_early_overdrive_access.option_early:
-            overdrive = choice(overdrive_items[:4])
+            overdrive = self.random.choice(overdrive_items[:4])
             self.multiworld.early_items[self.player][overdrive.itemName] = 1
         if self.options.tidus_early_overdrive_access.value is self.options.tidus_early_overdrive_access.option_start_with:
-            overdrive = choice(overdrive_items[:4])
+            overdrive = self.random.choice(overdrive_items[:4])
             self.multiworld.push_precollected(self.create_item(overdrive.itemName))
             required_items.remove(overdrive.itemName)
 

--- a/worlds/ffx/__init__.py
+++ b/worlds/ffx/__init__.py
@@ -247,7 +247,7 @@ class FFXWorld(World):
             "jecht_spheres": self.options.jecht_spheres.value,
             "always_capture": self.options.always_capture.value,
             "logic_difficulty": self.options.logic_difficulty.value,
-            "skip_contest_of_aeons": self.options.skip_contest_of_aeons,
+            "skip_contest_of_aeons": self.options.skip_contest_of_aeons.value,
         }
         return slot_data
 

--- a/worlds/ffx/items.py
+++ b/worlds/ffx/items.py
@@ -202,8 +202,8 @@ key_items: list[ItemData] = [ItemData(x[0], x[1], x[2] | keyItemOffset) for x in
     ("Mercury Sigil",               ItemClassification.progression, 0x0031),
     ("Blossom Crown",               ItemClassification.progression, 0x0032),
     ("Flower Scepter",              ItemClassification.progression, 0x0033),
-    # ("",                          ItemClassification.progression, 0x0034),
-    # ("",                          ItemClassification.progression, 0x0035),
+  # ("Neptune Crest",               ItemClassification.progression, 0x0034),
+  # ("Neptune Sigil",               ItemClassification.progression, 0x0035),
     # ("",                          ItemClassification.progression, 0x0036),
     # ("",                          ItemClassification.progression, 0x0037),
     # ("",                          ItemClassification.progression, 0x0038),
@@ -303,6 +303,7 @@ equip_items: list[ItemData] = [ItemData(x[0], x[1], x[2] | equipItemOffset) for 
     ("Weapon (Rikku): Infinity",            ItemClassification.useful     , 0x0053),  # Offset=0544 Weapon [00h], Formula=STR vs DEF [01h], Power=16, Crit=3%, Slots=2 {One MP Cost [800Dh], Sensor [8000h]} }
     ("Weapon (Lulu): Wicked Cait Sith",     ItemClassification.useful     , 0x0054),  # Offset=0554 Weapon [00h], Formula=STR vs DEF [01h], Power=16, Crit=3%, Slots=4 {Deathstrike [802Eh], Empty, Empty, Empty} }
     ("Weapon (Tidus): Hrunting",            ItemClassification.useful     , 0x0055),  # Offset=0564 Weapon [00h], Formula=STR vs DEF [01h], Power=16, Crit=3%, Slots=1 {SOS Overdrive [8010h]} }
+    ("Progressive Dimittis",                ItemClassification.progression, 0x0056),
 ]]
 
 party_member_items: list[ItemData] = [ItemData(x[0], x[1], x[2] | partyMemberItemOffset) for x in [
@@ -363,7 +364,7 @@ character_names = [
     "Wakka",
     "Lulu",
     "Rikku",
-    #"Seymour",
+    "Seymour",
 ]
 
 aeon_names = [

--- a/worlds/ffx/rules.py
+++ b/worlds/ffx/rules.py
@@ -239,7 +239,7 @@ class RangedRule(Rule[FFXWorld], game="Final Fantasy X"):
     
     @override
     def _instantiate(self, world: FFXWorld) -> Rule.Resolved:
-        return (HasFromListUnique(*[f"Party Member: {name}" for name in ["Wakka", "Lulu"]], count=1) | 
+        return (HasFromListUnique(*[f"Party Member: {name}" for name in ["Wakka", "Lulu", "Seymour"]], count=1) | 
                     (Has("Party Member: Yuna") & HasFromListUnique(*[f"Party Member: {name}" for name in aeon_names[:6]], count=1))).resolve(world)
 
 


### PR DESCRIPTION
Basic Seymour changes, including;
- 3x `Progressive Dimittis`
- Seymour now considered for `MinPartyRule` & `RangedRule`
  - This allows him to be logically considered for all bosses, as well as specifically for Sin Fin as well

Additionally I have added (but left commented out) the Neptune Crest & Sigil, for later implementation.
Some updates were made to the Early Party Member generation to use the correct random functions.

A fix was also put in place for the Skip Contest slot data, as it was previously failing generation due to passing the object, instead of the value.